### PR TITLE
add new files to win32

### DIFF
--- a/plasmvm/cpu/cpu.h
+++ b/plasmvm/cpu/cpu.h
@@ -259,4 +259,19 @@ void cpui_pushgen(void);
 void cpui_pullall(void);
 void cpui_pullgen(void);
 
+void cpuf_init(void);
+void cpuf_shutdown(void);
+
+void cpuf_timer_set(void);
+void cpuf_timer_clear(void);
+void cpuf_timer_wait(u32 ms);
+void cpuf_timer_setint(byte Vector, u32 ms);
+void cpuf_timer_clrint(byte Vector);
+
+void cpuf_power_set(void);
+void cpuf_power_clear(void);
+void cpuf_power_shutdown(void);
+void cpuf_power_sleep(void);
+void cpuf_power_restart(void);
+
 #endif /* cpu_h */

--- a/plasmvm/cpu/cpu_engine.c
+++ b/plasmvm/cpu/cpu_engine.c
@@ -6,6 +6,7 @@
 //
 
 #include "cpu.h"
+#include "features/cpuf.h"
 #include "../mmu/mmu.h"
 
 #include <stdlib.h>
@@ -14,6 +15,8 @@
 void cpu_init(void) {
 	ctx = malloc(sizeof(ictx_t));
 	memset(ctx, 0, sizeof(ictx_t));
+
+	cpuf_init();
 	return;
 }
 void cpu_clock(void) {
@@ -25,4 +28,5 @@ void cpu_opcode(byte Opcode) {
 }
 void cpu_shutdown(void) {
 	free(ctx);
+	cpuf_shutdown();
 }

--- a/plasmvm/cpu/cpu_ops.c
+++ b/plasmvm/cpu/cpu_ops.c
@@ -1373,3 +1373,47 @@ Instruction(FNRTX) {
 		ctx->FPR_SINGLE[REG_LO(Register)] = fpus_rooti(Immediate, ctx->FPR_SINGLE[REG_HI(Register)]);
 	return;
 } // 0xB4, // Floating nth-root with large root (FNRTX [I:(32,32),ROOT] [F:(4,8),SRC]):48
+
+Instruction(CPUFQ) {
+
+} // = 0xB8, // CPU Feature Query (CPUFQ [R:(4,4),FEATURE] [R:(4,4),DEST]):16
+
+Instruction(CPUFS) {
+
+} //  = 0xB9, // CPU Feature Set {Enabled} (CPUFQ [R:(4,8),FEATURE]):16
+
+Instruction(CPUFC) {
+
+} // = 0xBA, // CPU Feature Clear {Disabled} (CPUFQ [R:(4,8),FEATURE]):16
+
+Instruction(CPUFDB) {
+
+} // = 0xBB, // CPU Feature SendData Byte (CPUFDB [R:(4,4),FEATURE] [R:(4,4),DATA]):16
+
+Instruction(CPUFDQ) {
+
+} // = 0xBC, // CPU Feature SendData QuarterWord (CPUFDQ [R:(4,4),FEATURE] [R:(4,4),DATA]):16
+
+Instruction(CPUFDH) {
+
+} // = 0xBD, // CPU Feature SendData HalfWord (CPUFDH [R:(4,4),FEATURE] [R:(4,4),DATA]):16
+
+Instruction(CPUFDW) {
+
+} // = 0xBE, // CPU Feature SendData Word (CPUFDW [R:(4,4),FEATURE] [R:(4,4),DATA]):16
+
+Instruction(CPUFRB) {
+
+} // = 0xBF, // CPU Feature RecvData Byte (CPUFRB [R:(4,4),FEATURE] [R:(4,4),DEST]):16
+
+Instruction(CPUFRQ) {
+
+} // = 0xC0, // CPU Feature RecvData QuarterWord (CPUFRQ [R:(4,4),FEATURE] [R:(4,4),DEST]):16
+
+Instruction(CPUFRH) {
+
+} // = 0xC1, // CPU Feature RecvData HalfWord (CPUFRH [R:(4,4),FEATURE] [R:(4,4),DEST]):16
+
+Instruction(CPUFRW) {
+
+} // = 0xC2, // CPU Feature RecvData Word (CPUFRW [R:(4,4),FEATURE] [R:(4,4),DEST]):16

--- a/plasmvm/cpu/features/cpuf.h
+++ b/plasmvm/cpu/features/cpuf.h
@@ -1,0 +1,24 @@
+//
+//  cpu.h
+//  plasmvm
+//
+//  Created by Noah Wooten on 2/1/22.
+//
+
+#ifndef cpuf_h
+#define cpuf_h
+#include "../../ctx.h"
+
+typedef struct _cpufctx {
+	u32 TimerMs;
+	byte Interrupt;
+	union {
+		byte Flags;
+		struct {
+			byte Active : 1;
+		};
+	}Flags;
+}cpufctx_t;
+extern cpufctx_t* cpuf;
+
+#endif /* cpuf.h */

--- a/plasmvm/cpu/features/cpuf_engine.c
+++ b/plasmvm/cpu/features/cpuf_engine.c
@@ -1,0 +1,22 @@
+//
+//  cpuf_engine.c
+//  plasmvm
+//
+//  Created by Noah Wooten on 3/23/22.
+//
+#include "cpuf.h"
+cpufctx_t* cpuf;
+
+#include <stdlib.h>
+#include <string.h>
+
+void cpuf_init(void) {
+	cpuf = malloc(sizeof(cpufctx_t));
+	memset(cpuf, 0, sizeof(cpufctx_t));
+
+
+}
+
+void cpuf_shutdown(void) {
+
+}

--- a/plasmvm/cpu/features/cpuf_power.c
+++ b/plasmvm/cpu/features/cpuf_power.c
@@ -1,0 +1,6 @@
+//
+//  cpuf_power.c
+//  plasmvm
+//
+//  Created by Noah Wooten on 3/23/22.
+//

--- a/plasmvm/cpu/features/cpuf_timer.c
+++ b/plasmvm/cpu/features/cpuf_timer.c
@@ -1,0 +1,6 @@
+//
+//  cpuf_timer.c
+//  plasmvm
+//
+//  Created by Noah Wooten on 3/23/22.
+//

--- a/plasmvm/plasmvm.vcxproj
+++ b/plasmvm/plasmvm.vcxproj
@@ -140,6 +140,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="cpu\cpu.h" />
+    <ClInclude Include="cpu\features\cpuf.h" />
     <ClInclude Include="ctx.h" />
     <ClInclude Include="fpu\fpu.h" />
     <ClInclude Include="io\io.h" />
@@ -153,6 +154,9 @@
     <ClCompile Include="cpu\cpu_engine.c" />
     <ClCompile Include="cpu\cpu_handlers.c" />
     <ClCompile Include="cpu\cpu_ops.c" />
+    <ClCompile Include="cpu\features\cpuf_engine.c" />
+    <ClCompile Include="cpu\features\cpuf_power.c" />
+    <ClCompile Include="cpu\features\cpuf_timer.c" />
     <ClCompile Include="io\io_bus.c" />
     <ClCompile Include="io\io_load.c" />
     <ClCompile Include="io\kb\kb_events.c" />

--- a/plasmvm/plasmvm.vcxproj.filters
+++ b/plasmvm/plasmvm.vcxproj.filters
@@ -39,6 +39,9 @@
     <ClInclude Include="fpu\fpu.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="cpu\features\cpuf.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="cpu\cpu_advops.c">
@@ -108,6 +111,15 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="fpu\impl\softmath\fpu_softtrig.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="cpu\features\cpuf_timer.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="cpu\features\cpuf_power.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="cpu\features\cpuf_engine.c">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
This is currently broken on Xcode/macOS (Legacy and Latest). This is due to the new C files being unable to be added to the project. This will be still compile under clang/make and msvc on all platforms. The new files will be added the pbproj file soon, but my macOS install is currently out of service.